### PR TITLE
Added FSpectate.getSpecEnt() for clients

### DIFF
--- a/lua/fspectate/cl_init.lua
+++ b/lua/fspectate/cl_init.lua
@@ -1,3 +1,5 @@
+FSpectate = {}
+
 local stopSpectating, startFreeRoam
 local isSpectating = false
 local specEnt
@@ -6,6 +8,17 @@ local isRoaming = false
 local roamPos -- the position when roaming free
 local roamVelocity = Vector(0)
 local thirdPersonDistance = 100
+
+/*---------------------------------------------------------------------------
+Retrieve the current spectated player
+---------------------------------------------------------------------------*/
+function FSpectate.getSpecEnt()
+	if isSpectating and not isRoaming then
+		return IsValid(specEnt) and specEnt or nil
+	else
+		return nil
+	end
+end
 
 /*---------------------------------------------------------------------------
 startHooks


### PR DESCRIPTION
New function that allows to grab the current _specEnt_ from **FSpectate**.
This is useful to set the HUD information to the spectated player.

Copied from [Added FSpectate.getSpecEnt() for clients #2539](https://github.com/FPtje/DarkRP/pull/2539)