### PR TITLE
Fix pattern for bind fspectate

### DIFF
--- a/lua/fspectate/cl_init.lua
+++ b/lua/fspectate/cl_init.lua
@@ -208,7 +208,7 @@ local function specBinds(ply, bind, pressed)
 
         return true
     elseif isRoaming and not LocalPlayer():KeyDown(IN_USE) then
-        local keybind = string.lower(string.match(bind, "+([a-z A-Z 0-9]+)") or "")
+        local keybind = string.lower(string.match(bind, "([+a-zA-Z0-9]+)") or "")
         if not keybind or keybind == "use" or keybind == "showscores" or string.find(bind, "messagemode") then return end
 
         keysDown[keybind:upper()] = pressed


### PR DESCRIPTION
```
| It creates an error.
|
|     | Spaces are not needed.
|     |   |
V     V   V
+([a-z A-Z 0-9]+)
```
Duplicate of https://github.com/FPtje/DarkRP/pull/2926