### PR TITLE
Reduce Impact on Server performance

### DIFF
--- a/lua/fspectate/sv_init.lua
+++ b/lua/fspectate/sv_init.lua
@@ -23,12 +23,18 @@ local function findPlayer(info)
     return nil
 end
 
+local FSpectating = {}
+-- For Lua Refresh
+for k,v in ipairs(player.GetHumans()) do
+    FSpectating[v] = v.FSpectating
+end
 local function startSpectating(ply, target)
     local canSpectate = hook.Call("FSpectate_canSpectate", nil, ply, target)
     if canSpectate == false then return end
 
     ply.FSpectatingEnt = target
     ply.FSpectating = true
+    FSpectating[ply] = true
 
     ply:ExitVehicle()
 
@@ -115,31 +121,41 @@ local function endSpectate(ply, cmd, args)
     ply.FSpectatingEnt = nil
     ply.FSpectating = nil
     ply.FSpectatePos = nil
+    FSpectating[ply] = nil
     hook.Call("FSpectate_stop", nil, ply)
 end
 concommand.Add("FSpectate_StopSpectating", endSpectate)
 
 local vrad = DarkRP and GM.Config.voiceradius
-local voiceDistance = DarkRP and GM.Config.voiceDistance * GM.Config.voiceDistance
+local voiceDistance = DarkRP and GM.Config.voiceDistance * GM.Config.voiceDistance or 302500 -- Default 550 units
 local function playerVoice(listener, talker)
-    if not listener.FSpectating then return end
+    if not FSpectating[listener] then return end
 
     local canHearLocal, surround = GAMEMODE:PlayerCanHearPlayersVoice(listener, talker)
+
+    -- No need to check other stuff
+    if canHearLocal then
+        return canHearLocal, surround
+    end
 
     local FSpectatingEnt = listener.FSpectatingEnt
     if not IsValid(FSpectatingEnt) or not FSpectatingEnt:IsPlayer() then
         local spectatePos = IsValid(FSpectatingEnt) and FSpectatingEnt:GetPos() or listener.FSpectatePos
         if not vrad or not spectatePos then return end
 
-        -- Return whether the listener can hear the talker locally or distance smaller than 550
-        return canHearLocal or spectatePos:DistToSqr(talker:GetShootPos()) < voiceDistance, surround
+        -- Return whether the listener is a in distance smaller than 550
+        return spectatePos:DistToSqr(talker:GetPos()) < voiceDistance, surround
+    end
+
+    -- you can always hear the person you're spectating
+    if FSpectatingEnt == talker then
+        return true, surround
     end
 
     -- You can hear someone if your spectate target can hear them
     local canHear = GAMEMODE:PlayerCanHearPlayersVoice(FSpectatingEnt, talker)
 
-    -- you can always hear the person you're spectating
-    return canHear or canHearLocal or FSpectatingEnt == talker, surround
+    return canHear, surround
 end
 hook.Add("PlayerCanHearPlayersVoice", "FSpectate", playerVoice)
 

--- a/lua/fspectate/sv_init.lua
+++ b/lua/fspectate/sv_init.lua
@@ -25,7 +25,7 @@ end
 
 local FSpectating = {}
 -- For Lua Refresh
-for k,v in ipairs(player.GetHumans()) do
+for _,v in ipairs(player.GetHumans()) do
     FSpectating[v] = v.FSpectating
 end
 local function startSpectating(ply, target)


### PR DESCRIPTION
This code was a mess. It would calculate more checks than needed. So I took steps to reduce them.

Changes:
- Changed the check to see if the player spectating. It would use the .\_\_index method. But this calls ply:GetTable() then indexs the table. By just checking a local table it makes it real quick.

You may see this as a micro optimisation but this is really needed in this hook. `PlayerCanHearPlayersVoice` to my knowledge runs as a O(N^2) each tick where N is the number of players. So on an 16 tickrate server with 100 players this would run 160000 times in one second, meaning any optimisation really boosts this.

I kept the old var just incase any addon used it for whatever reason.

I also did some performance tests using some using both methods with of just checking the var. Was ran for a simulated 100 ticks with 99 players (tested on live server).

```
old version took: 0.092327338999894
new version took: 0.0014285590004874
```
<details><summary>Code</summary>
<p>

This does check if the player can hear themself but it still does compare the performace as they both do it.

```lua
function check(func, name)
	local timee = SysTime()
	for i=1, 100 do
		func()
	end
	print(name.." took: "..SysTime() -  timee)
end

local function performance(num)
	local x
	local plys = player.GetHumans()
	for k,v in ipairs(plys) do
		for k2,v2 in ipairs(plys) do
			x = !v2.FSpectate
		end
	end
end
check(performance, "old version")

local FSpectate = {}
local function performance2(number)
	local x
	local plys = player.GetHumans()
	for k,v in ipairs(plys) do
		for k2,v2 in ipairs(plys) do
			x = !FSpectate[v2]
		end
	end
end
check(performance2, "new version")
```


</p>
</details>

As you can see very quick :)

- If the player can hear them at their body they will always hear them. Beforehand if the player they were spectating was not a player or invalid and the spectate pos or vrad was nil you would not hear people near to you. This is now fixed.

- Better non-Darkrp support. If the gamemode was not DarkRP the`voiceDistance`var would not  be set. Causing the distance check to compare to a nil value. So I changed it to default to 550 units as specified by the comment above it.

- If the Entity you were spectating was the person talking it would check if they could hear them normally then just let them hear it anyway. So now it just lets them hear them.

I debated the last one as it might not be needed as hook is just two array indexes but GAMEMODE hook calls are slow in the default hook library so I added it. It can be reverted. Also other gamemode Voice checks might be worse than DarkRP's.

