### PR TITLE
Remove unnecessary function call in cl_init.lua

### DIFF
--- a/lua/fspectate/cl_init.lua
+++ b/lua/fspectate/cl_init.lua
@@ -48,7 +48,6 @@ hook.Add("Initialize", "FSpectate", function()
                 canSpectate = b
             end)
         end
-        calcAccess()
 
         -- Spectate option in player menu
         FAdmin.ScoreBoard.Player:AddActionButton("Spectate", "fadmin/icons/spectate", Color(0, 200, 0, 255), function(ply) calcAccess() return canSpectate and ply ~= LocalPlayer() end, function(ply)


### PR DESCRIPTION
This causes ulib to error (if it gets called before FAdmin hook) because it doesn't check for null entities in clientside :D